### PR TITLE
Containerize Postgres

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+POSTGRES_DB=caturl
+POSTGRES_USER=caturl
+POSTGRES_PASSWORD=caturl

--- a/README.md
+++ b/README.md
@@ -3,5 +3,4 @@ Redoing [cat-url-mangler](https://github.com/loopDelicious/cat-url-mangler) in N
 ### For Development
 
     npm start // start app, running on 3000
-    node server.js // start server, running on 5500
-    pg_ctl -D /usr/local/var/postgres start // start postgres, running on 5432
+    npm run start-server // start server, running on 5500. Automatically starts postgres inside a docker container

--- a/bin/dev_server.sh
+++ b/bin/dev_server.sh
@@ -1,0 +1,28 @@
+PROJECT="caturl"
+
+# Ensure node dependencies
+NODE_ENV="development" yarn --no-progress --no-emoji --prefer-offline
+
+# Start containerized dependencies if not running (ie postgres)
+docker-compose -p ${PROJECT} up -d
+
+# getPort $containerName $containerPort
+function getPort {
+  docker inspect "$(docker ps -a --latest --filter=name=${PROJECT}_${1} -q)" --format="{{(index (index .NetworkSettings.Ports \"${2}\") 0).HostPort}}"
+}
+
+# Source development environment variables (postgres)
+set -a
+source .env.development
+set +a
+
+DB_NAME=$POSTGRES_DB \
+DB_USER=$POSTGRES_USER \
+DB_PASSWORD=$POSTGRES_PASSWORD \
+DB_HOST="localhost" \
+DB_PORT="$(getPort postgres 5432/tcp)" \
+./node_modules/.bin/nodemon \
+    --inspect \
+    --ignore src/components \
+    --ignore src/css \
+    server.js

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  postgres:
+    image: postgres:10
+    restart: on-failure
+    env_file:
+      - .env.development
+    ports:
+      - 5432

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "fs": "0.0.1-security",
+    "nodemon": "^1.18.10",
     "pg": "^7.7.1",
     "pg-promise": "^8.5.4",
     "react": "^16.7.0",
@@ -15,6 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start-server": "./bin/dev_server.sh",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/db/model.js
+++ b/src/db/model.js
@@ -1,12 +1,12 @@
 const { Client } = require('pg');
 
 const client = new Client({
-    // user: 'dbuser',
-    host: 'localhost',
-    database: 'caturl',
-    // password: 'secretpassword',
-    port: 5432
-});
+  user: process.env.DB_USER || null,
+  host: process.env.DB_HOST || 'localhost',
+  database: process.env.DB_NAME || 'caturl',
+  password: process.env.DB_PASSWORD || null,
+  port: process.env.DB_PORT || 5432
+})
 
 const clientConnect = () => {
     


### PR DESCRIPTION
This PR adds a bash script that runs when starting the dev server via `npm run start-server`. It starts up a postgres container if not already running, and tells your app how to connect to it via environment variables.

Ideally this should make things easier by removing one less dependency to worry about.

If you want to see your postgres container in docker, just run `docker ps`. It should be named something like `caturl_postgres_1`. If you want to delete the container (and all the data in the db), you can then run `docker rm caturl_postgres_1` and a new container will be created next time you start your app.